### PR TITLE
feat: implement NTAG/Ultralight read and write

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -15,6 +15,11 @@ toc:
       - Pn532WebserialAdapter
   - name: Example
     children:
+      - name: NTAG / MIFARE Ultralight Toolkit
+        description: |
+          URL: <http://taichunmin.idv.tw/pn532.js/ntag-toolkit.html>
+
+          This tools can read or write data from NTAG / MIFARE Ultralight tags via Web Bluetooth or Web Serial.
       - name: M1 UID4B Writer
         description: |
           URL: <http://taichunmin.idv.tw/pn532.js/m1-uid4b-writer.html>

--- a/src/plugin/Hf14a.js
+++ b/src/plugin/Hf14a.js
@@ -1133,6 +1133,192 @@ export default class Pn532Hf14a {
       }
     }
 
+    /**
+     * Read a page from NTAG / MIFARE Ultralight.
+     * The MIFARE Ultralight READ command returns 4 consecutive pages (16 bytes)
+     * starting from the specified page address.
+     * @memberof Pn532Hf14a
+     * @instance
+     * @async
+     * @param {object} args
+     * @param {number} args.page Target page address (0x00 ~ 0xFF).
+     * @param {number} args.tg Logical number of the relevant target.
+     * @returns {Promise<Packet>} Resolve with 16 bytes (4 pages starting from the target page).
+     */
+    async function mfUltralightReadPage ({ page = 0, tg = 1 } = {}) {
+      const resp = await retry(async () => {
+        try {
+          return await pn532.inDataExchange({
+            tg,
+            data: new Packet([0x30, page & 0xFF]),
+          })
+        } catch (err) {
+          if (!isAdapterOpen()) throw err
+          throw new Error(`Failed to read page ${page}`)
+        }
+      })
+      return resp?.data
+    }
+
+    /**
+     * Read a page from NTAG / MIFARE Ultralight with card selection and release.
+     * @memberof Pn532Hf14a
+     * @instance
+     * @async
+     * @param {object} args
+     * @param {number} args.page Target page address (0x00 ~ 0xFF).
+     * @param {number} args.timeout The maxinum timeout for waiting response.
+     * @returns {Promise<Packet>} Resolve with 16 bytes.
+     */
+    async function mfUltralightReadPageWrapped ({ page = 0, timeout } = {}) {
+      try {
+        const target = (await inListPassiveTarget({ timeout }))?.[0]
+        if (!target) throw new Error('Failed to select card')
+        return await mfUltralightReadPage({ page })
+      } finally {
+        await inReleaseIfOpened()
+      }
+    }
+
+    /**
+     * Write 4 bytes data to a single page of NTAG / MIFARE Ultralight.
+     * @memberof Pn532Hf14a
+     * @instance
+     * @async
+     * @param {object} args
+     * @param {number} args.page Target page address (0x00 ~ 0xFF).
+     * @param {Packet} args.data 4 bytes page data to write.
+     * @param {number} args.tg Logical number of the relevant target.
+     * @returns {Promise<null>} Resolve after finished.
+     */
+    async function mfUltralightWritePage ({ page = 0, data, tg = 1 } = {}) {
+      if (!Packet.isLen(data, 4)) throw new TypeError('invalid data, expected 4 bytes')
+      await retry(async () => {
+        try {
+          await pn532.inDataExchange({
+            tg,
+            data: new Packet([0xA2, page & 0xFF, ...data]),
+          })
+        } catch (err) {
+          if (!isAdapterOpen()) throw err
+          throw new Error(`Failed to write page ${page}`)
+        }
+      })
+    }
+
+    /**
+     * Write 4 bytes data to a single page of NTAG / MIFARE Ultralight with card selection and release.
+     * @memberof Pn532Hf14a
+     * @instance
+     * @async
+     * @param {object} args
+     * @param {number} args.page Target page address (0x00 ~ 0xFF).
+     * @param {Packet} args.data 4 bytes page data to write.
+     * @param {number} args.timeout The maxinum timeout for waiting response.
+     * @returns {Promise<null>} Resolve after finished.
+     */
+    async function mfUltralightWritePageWrapped ({ page = 0, data, timeout } = {}) {
+      try {
+        const target = (await inListPassiveTarget({ timeout }))?.[0]
+        if (!target) throw new Error('Failed to select card')
+        await mfUltralightWritePage({ page, data })
+      } finally {
+        await inReleaseIfOpened()
+      }
+    }
+
+    /**
+     * Write an NDEF URI to NTAG / MIFARE Ultralight.
+     * prefixes source: https://austinblackstoneengineering.com/nfc-p2p-basics/
+     * @memberof Pn532Hf14a
+     * @instance
+     * @async
+     * @param {object} args
+     * @param {string} args.uri The URI to write (e.g. 'https://example.com').
+     * @param {number} args.timeout The maxinum timeout for waiting response.
+     * @returns {Promise<null>} Resolve after finished.
+     */
+    async function mfUltralightWriteNdefUri ({ uri = '', timeout } = {}) {
+      const prefixes = [
+        { p: 'ftp://anonymous:anonymous@', c: 0x07 },
+        { p: 'https://www.', c: 0x02 },
+        { p: 'urn:epc:tag:', c: 0x1F },
+        { p: 'urn:epc:pat:', c: 0x20 },
+        { p: 'urn:epc:raw:', c: 0x21 },
+        { p: 'http://www.', c: 0x01 },
+        { p: 'urn:epc:id:', c: 0x1E },
+        { p: 'irdaobex://', c: 0x1C },
+        { p: 'tcpobex://', c: 0x1B },
+        { p: 'btl2cap://', c: 0x19 },
+        { p: 'ftp://ftp.', c: 0x08 },
+        { p: 'btgoep://', c: 0x1A },
+        { p: 'telnet://', c: 0x10 },
+        { p: 'btspp://', c: 0x18 },
+        { p: 'urn:nfc:', c: 0x23 },
+        { p: 'urn:epc:', c: 0x22 },
+        { p: 'https://', c: 0x04 },
+        { p: 'mailto:', c: 0x06 },
+        { p: 'http://', c: 0x03 },
+        { p: 'sftp://', c: 0x0A },
+        { p: 'rtsp://', c: 0x12 },
+        { p: 'ftps://', c: 0x09 },
+        { p: 'file://', c: 0x1D },
+        { p: 'smb://', c: 0x0B },
+        { p: 'nfs://', c: 0x0C },
+        { p: 'ftp://', c: 0x0D },
+        { p: 'dav://', c: 0x0E },
+        { p: 'news:', c: 0x0F },
+        { p: 'sips:', c: 0x16 },
+        { p: 'tftp:', c: 0x17 },
+        { p: 'tel:', c: 0x05 },
+        { p: 'sip:', c: 0x15 },
+        { p: 'urn:', c: 0x13 },
+        { p: 'pop:', c: 0x14 },
+        { p: 'imap:', c: 0x11 },
+      ]
+      let prefixCode = 0x00
+      let uriStr = uri
+      for (const { p, c } of prefixes) {
+        if (uri.startsWith(p)) {
+          prefixCode = c
+          uriStr = uri.slice(p.length)
+          break
+        }
+      }
+
+      const uriBytes = Packet.fromUtf8(uriStr)
+      const payloadLength = 1 + uriBytes.length
+
+      const ndef = new Packet([
+        0xD1, // MB=1, ME=1, CF=0, SR=1, IL=0, TNF=1
+        0x01, // Type Length
+        payloadLength,
+        0x55, // Type 'U'
+        prefixCode,
+        ...uriBytes,
+      ])
+
+      const tlvLen = ndef.length
+      const tlv = tlvLen < 255
+        ? new Packet([0x03, tlvLen, ...ndef, 0xFE])
+        : new Packet([0x03, 0xFF, (tlvLen >>> 8) & 0xFF, tlvLen & 0xFF, ...ndef, 0xFE])
+
+      const paddedLen = Math.ceil(tlv.length / 4) * 4
+      const data = new Packet(paddedLen)
+      data.set(tlv)
+
+      try {
+        const target = (await inListPassiveTarget({ timeout }))?.[0]
+        if (!target) throw new Error('Failed to select card')
+
+        for (let i = 0; i < data.length; i += 4) {
+          await mfUltralightWritePage({ page: 4 + (i / 4), data: data.subarray(i, i + 4) })
+        }
+      } finally {
+        await inReleaseIfOpened()
+      }
+    }
+
     return {
       inListPassiveTarget,
       mfAuthBlock,
@@ -1153,6 +1339,11 @@ export default class Pn532Hf14a {
       mfSelectCard,
       mfSetUidGen1a,
       mfSetUidGen2,
+      mfUltralightReadPage,
+      mfUltralightReadPageWrapped,
+      mfUltralightWriteNdefUri,
+      mfUltralightWritePage,
+      mfUltralightWritePageWrapped,
       mfWipeGen1a,
       mfWriteBlock,
       mfWriteBlockGen1a,

--- a/web/ntag-toolkit.pug
+++ b/web/ntag-toolkit.pug
@@ -1,0 +1,185 @@
+extends /layout/default
+
+block beforehtml
+  - const title = 'NTAG / MIFARE Ultralight 工具'
+
+block style
+  meta(property="og:description", content=title)
+  meta(property="og:locale", content="zh_TW")
+  meta(property="og:title", content=title)
+  meta(property="og:type", content="website")
+  meta(property="og:url", content=`${baseurl}ntag-toolkit.html`)
+  style
+    :sass
+      [v-cloak]
+        display: none
+      body, .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6
+        font-family: 'Noto Sans TC', sans-serif
+
+block content
+  #app.my-3.container.text-monospace(v-cloak)
+    h2.mb-3.text-center= title
+    
+    .card.my-2
+      .card-body
+        .form-group.mb-3
+          label 選擇 PN532 的連線方式
+          select.form-control.form-control-sm(v-model="h.adapter")
+            option(value="ble") 透過藍芽 BLE 連線 (支援 PC 及 Android)
+            option(value="usb") 透過 USB Serial 連線 (支援 PC)
+            
+        hr
+        h5.card-title 讀取 Page (Read)
+        small.text-muted NTAG 每次讀取會回傳從目標 Page 開始的 4 個 Page (共 16 bytes)。
+        .input-group.input-group-sm.my-2
+          .input-group-prepend: span.input-group-text 頁數 (Page)
+          input.form-control(v-model.number="readPage", type="number", min="0", max="255")
+          .input-group-append: button.btn.btn-success(type="button", @click="btnReadPage") 讀取
+          
+        .form-group.mt-3(v-if="readResult")
+          label 讀取結果 (Hex)
+          textarea.form-control.text-monospace(readonly, rows="4", v-model="readResult")
+          
+        hr.mt-4
+        h5.card-title 寫入 Page (Write)
+        small.text-muted 每次只能寫入單一 Page (精確 4 bytes)。警告：請確認寫入的 Page 不是唯讀的 (例如 OTP, Lock bytes)，否則可能損壞卡片。
+        .input-group.input-group-sm.my-2
+          .input-group-prepend: span.input-group-text 頁數 (Page)
+          input.form-control(v-model.number="writePage", type="number", min="0", max="255")
+        .input-group.input-group-sm.mb-2
+          .input-group-prepend: span.input-group-text 資料 (Hex)
+          input.form-control(v-model="writeData", placeholder="請輸入 8 個十六進位字元 (4 bytes)，例如: AABBCCDD", pattern="[\\dA-Fa-f]{8}")
+        button.btn.btn-danger.btn-block.btn-sm.mt-3(type="button", @click="btnWritePage") 寫入單一 Page
+
+        hr.mt-4
+        h5.card-title 寫入 NDEF 網址 (Write URL)
+        small.text-muted 將網址寫入 NTAG (從 Page 4 開始寫入 NDEF 格式)。警告：將會覆蓋卡片內現有的資料！
+        .input-group.input-group-sm.my-2
+          .input-group-prepend: span.input-group-text 網址 (URL)
+          input.form-control(v-model="writeUrl", placeholder="例如: https://example.com")
+        button.btn.btn-warning.btn-block.btn-sm.mt-3(type="button", @click="btnWriteUrl") 寫入網址
+
+block script
+  script.
+    const {
+      Pn532: { Pn532, Packet },
+      Pn532Hf14a,
+      Pn532LoggerRxTx,
+      Pn532WebbleAdapter,
+      Pn532WebserialAdapter,
+    } = window
+
+    // usb adapter
+    const pn532usb = new Pn532()
+    pn532usb.use(new Pn532WebserialAdapter())
+    pn532usb.use(new Pn532Hf14a())
+
+    // ble adapter
+    const pn532ble = new Pn532()
+    pn532ble.use(new Pn532WebbleAdapter())
+    pn532ble.use(new Pn532Hf14a())
+
+    if (new URL(location).searchParams.has('debug')) {
+      pn532usb.use(new Pn532LoggerRxTx())
+      pn532ble.use(new Pn532LoggerRxTx())
+    }
+
+    window.vm = new Vue({
+      el: '#app',
+      data: {
+        h: {
+          adapter: 'ble',
+        },
+        readPage: 0,
+        readResult: '',
+        writePage: 4,
+        writeData: '00000000',
+        writeUrl: 'https://taichunmin.idv.tw/',
+      },
+      async mounted () {
+        // 自動儲存設定
+        try {
+          const saved = JSON5.parse(localStorage.getItem(location.pathname))
+          if (saved) this.$set(this, 'h', { ...this.h, ...saved })
+        } catch (err) {}
+        this.$watch('h', () => {
+          localStorage.setItem(location.pathname, JSON5.stringify(this.h))
+        }, { deep: true })
+      },
+      computed: {
+        pn532 () {
+          return this.h.adapter === 'usb' ? pn532usb : pn532ble
+        },
+      },
+      methods: {
+        async btnReadPage () {
+          try {
+            this.showLoading('正在讀取...', '請將卡片靠近讀卡機')
+            const data = await this.pn532.$hf14a.mfUltralightReadPageWrapped({ page: this.readPage })
+            // Format 16 bytes into 4 lines of 4 bytes
+            const chunks = data.chunk(4).map(chunk => chunk.hex.toUpperCase())
+            this.readResult = chunks.map((hex, i) => `Page ${this.readPage + i}: ${hex}`).join('\n')
+            await Swal.fire({ icon: 'success', title: '讀取成功' })
+          } catch (err) {
+            console.error(err)
+            await Swal.fire({ icon: 'error', title: '讀取失敗', text: err.message })
+          }
+        },
+        async btnWritePage () {
+          try {
+            const hexData = this.writeData.trim()
+            if (!/^[0-9A-Fa-f]{8}$/.test(hexData)) {
+              throw new Error('請輸入正確的 4 Bytes Hex 資料 (8 個字元)')
+            }
+            if (!await this.confirm(`確定要將資料寫入 Page ${this.writePage} 嗎？此操作具有破壞性！`, '寫入', '取消')) return
+            
+            this.showLoading('正在寫入...', '請將卡片靠近讀卡機')
+            const packetData = Packet.fromHex(hexData)
+            await this.pn532.$hf14a.mfUltralightWritePageWrapped({ 
+              page: this.writePage, 
+              data: packetData 
+            })
+            await Swal.fire({ icon: 'success', title: '寫入成功' })
+          } catch (err) {
+            console.error(err)
+            await Swal.fire({ icon: 'error', title: '寫入失敗', text: err.message })
+          }
+        },
+        async btnWriteUrl () {
+          try {
+            const url = this.writeUrl.trim()
+            if (!url) throw new Error('請輸入網址')
+            if (!await this.confirm(`確定要將網址寫入卡片嗎？此操作會覆蓋現有資料！`, '寫入', '取消')) return
+            
+            this.showLoading('正在寫入...', '請將卡片靠近讀卡機')
+            await this.pn532.$hf14a.mfUltralightWriteNdefUri({ uri: url })
+            await Swal.fire({ icon: 'success', title: '寫入成功' })
+          } catch (err) {
+            console.error(err)
+            await Swal.fire({ icon: 'error', title: '寫入失敗', text: err.message })
+          }
+        },
+        async confirm (text, confirmButtonText, cancelButtonText) {
+          const args = {
+            cancelButtonColor: '#3085d6',
+            cancelButtonText,
+            confirmButtonColor: '#d33',
+            confirmButtonText,
+            focusCancel: true,
+            icon: 'warning',
+            showCancelButton: true,
+            text,
+          }
+          return (await Swal.fire(args))?.isConfirmed
+        },
+        showLoading (title, text) {
+          Swal.fire({
+            title,
+            text,
+            allowOutsideClick: false,
+            showConfirmButton: false,
+            willOpen: () => { Swal.showLoading() },
+          })
+        },
+      },
+    })


### PR DESCRIPTION
## Description
implement NTAG/Ultralight read and write for #8 

### Changes
- **Core Library (`Hf14a.js`)**:
  - Implemented the `mfUltralightWriteNdefUri` function to automatically encode a given URL into standard NDEF format (including URI RTD and TLV blocks) and sequentially write it to the tag starting from Page 4.
  - Included a complete table of 35 NFC Forum URI prefixes to optimize and compress the NDEF payload size efficiently.
  - Managed proper connection states (`inListPassiveTarget` / `inReleaseIfOpened`) within the function to ensure the stability and performance of continuous multi-page writes.
- **UI & Documentation (`ntag-toolkit.pug`, `documentation.yml`)**:
  - Added a new NTAG-Toolkit website.
  - Updated example links in the documentation.